### PR TITLE
Add support to Alarm Panel for Custom Bypass

### DIFF
--- a/custom_components/scout_alarm/__init__.py
+++ b/custom_components/scout_alarm/__init__.py
@@ -17,7 +17,8 @@ from homeassistant.const import (
     CONF_PASSWORD,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_NIGHT
+    STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS
 )
 
 import voluptuous as vol
@@ -37,7 +38,8 @@ CONFIG_SCHEMA = vol.Schema(
                     {
                         vol.Optional(STATE_ALARM_ARMED_AWAY): cv.string,
                         vol.Optional(STATE_ALARM_ARMED_HOME): cv.string,
-                        vol.Optional(STATE_ALARM_ARMED_NIGHT): cv.string
+                        vol.Optional(STATE_ALARM_ARMED_NIGHT): cv.string,
+                        vol.Optional(STATE_ALARM_ARMED_CUSTOM_BYPASS): cv.string
                     }
                 )
             }

--- a/custom_components/scout_alarm/alarm_control_panel.py
+++ b/custom_components/scout_alarm/alarm_control_panel.py
@@ -12,6 +12,7 @@ from homeassistant.components.alarm_control_panel.const import (
     SUPPORT_ALARM_ARM_AWAY,
     SUPPORT_ALARM_ARM_HOME,
     SUPPORT_ALARM_ARM_NIGHT,
+    SUPPORT_ALARM_ARM_CUSTOM_BYPASS
 )
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
@@ -20,6 +21,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_DISARMED,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS,
     STATE_ALARM_ARMING,
     STATE_ALARM_PENDING,
     STATE_ALARM_TRIGGERED,
@@ -126,6 +128,8 @@ class ScoutAlarmControlPanel(alarm.AlarmControlPanelEntity):
             features |= SUPPORT_ALARM_ARM_AWAY
         if self.state_to_mode.get(STATE_ALARM_ARMED_NIGHT):
             features |= SUPPORT_ALARM_ARM_NIGHT
+        if self.state_to_mode.get(STATE_ALARM_ARMED_CUSTOM_BYPASS):
+            features |= SUPPORT_ALARM_ARM_CUSTOM_BYPASS
 
         return features
 
@@ -155,6 +159,11 @@ class ScoutAlarmControlPanel(alarm.AlarmControlPanelEntity):
         night_mode = self.__mode_for_state(STATE_ALARM_ARMED_NIGHT)
         if night_mode:
             await self._api.update_mode_state(night_mode['id'], SCOUT_MODE_ARMING)
+
+    async def async_alarm_arm_custom_bypass(self, code=None):
+        bypass_mode = self.__mode_for_state(STATE_ALARM_ARMED_CUSTOM_BYPASS)
+        if bypass_mode:
+            await self._api.update_mode_state(bypass_mode['id'], SCOUT_MODE_ARMING)
 
     async def async_update(self):
         """Update device state."""

--- a/custom_components/scout_alarm/config_flow.py
+++ b/custom_components/scout_alarm/config_flow.py
@@ -10,7 +10,8 @@ from homeassistant.const import (
     CONF_USERNAME,
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_NIGHT,
-    STATE_ALARM_ARMED_HOME
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_CUSTOM_BYPASS
 )
 
 from .const import DOMAIN, CONF_MODES, LOGGER
@@ -68,8 +69,9 @@ class ScoutAlarmConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         night_mode = user_input.get(STATE_ALARM_ARMED_NIGHT)
         away_mode = user_input.get(STATE_ALARM_ARMED_AWAY)
         home_mode = user_input.get(STATE_ALARM_ARMED_HOME)
+        bypass_mode = user_input.get(STATE_ALARM_ARMED_CUSTOM_BYPASS)
 
-        if not night_mode and not away_mode and not home_mode:
+        if not night_mode and not away_mode and not home_mode and not bypass_mode:
             return await self._async_show_modes_form(errors={"base": "mode_mapping_required"})
 
         return self._create_entry(user_input)
@@ -134,7 +136,8 @@ class ScoutAlarmConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Optional(STATE_ALARM_ARMED_HOME): vol.In(scout_modes),
                     vol.Optional(STATE_ALARM_ARMED_AWAY): vol.In(scout_modes),
-                    vol.Optional(STATE_ALARM_ARMED_NIGHT): vol.In(scout_modes)
+                    vol.Optional(STATE_ALARM_ARMED_NIGHT): vol.In(scout_modes),
+                    vol.Optional(STATE_ALARM_ARMED_CUSTOM_BYPASS): vol.In(scout_modes)
                 }
             ),
             errors=errors

--- a/custom_components/scout_alarm/translations/en.json
+++ b/custom_components/scout_alarm/translations/en.json
@@ -23,7 +23,8 @@
                 "data": {
                     "armed_away": "Away mode",
                     "armed_home": "Armed at Home mode",
-                    "armed_night": "Night mode"
+                    "armed_night": "Night mode",
+                    "armed_custom_bypass": "Bypass mode"
                 },
                 "title": "Map HA states to your Scout modes"
             }


### PR DESCRIPTION
Added support to Alarm Panel for Custom Bypass mode.  To test this, just add a fourth mode in addition to Home, Away and Sleep.  This branch was cut from Master so it does _not_ include the other sensor changes.  This way you can evaluate and merge the two branches separately as you see fit.